### PR TITLE
Switch to Subcommand CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,10 @@ Graph operations on a collection of interlinked Markdown (or
 ```
 md-graph - A utility for graph operations on a collection of markdown files
 
-Usage: md-graph [(-l|--library FILE|DIR) [-l|--library FILE|DIR]] 
-                [-d|--default-ext EXT] COMMAND
+Usage: md-graph [(-l|--library FILE|DIR)] [-d|--default-ext EXT] COMMAND
 
 Available options:
   -h,--help                Show this help text
-  -l,--library FILE|DIR    Files or directories to parse
   -l,--library FILE|DIR    Files or directories to parse
   -d,--default-ext EXT     Default extension to use for files linked without
                            extension (default: "md")

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Available options:
   --depth ARG              How deep traversal should go (default: -1)
   -h,--help                Show this help text
 ```
+- `NODES` The target files or tags to act as the start of the subgraph.
 - `--inc-static=True|False` Default `True`. Includes static files in 
     the output (files that were linked to and can be resolved)
 - `--inc-nonex=True|False` Default `False`. Includes non-existent files in 
@@ -60,6 +61,8 @@ Available options:
     - `In`: The link is coming **in** to the tag from the file
     - `Out`: The link is from the tag **out** to the file
     - `Both`: The tag and the file **both** have links to each other.
+- `--depth INT` Default `-1` (infinite depth). Configures how many links deep 
+    from the target NODES a subgraph should traverse.
 
 ### Backlinks
 ```
@@ -71,9 +74,9 @@ Available options:
   --depth ARG              How deep traversal should go (default: 1)
   -h,--help                Show this help text
 ```
-
-- Optional:
-
+- `NODES` The target files or tags to act as the start of the subgraph.
+- `--depth INT` Default `1` (immediate links only). Configures how many links 
+    deep from the target NODES a subgraph should traverse.
 
 ### Nodes: Files & Tags
 Arguments that take a "`NODE`" (such as `subgraph` and `backlinks`) can be given 

--- a/README.md
+++ b/README.md
@@ -7,45 +7,80 @@ Graph operations on a collection of interlinked Markdown (or
 
 ## Usage
 ```
-Usage: md-graph (-l|--library FILE|DIR) [-d|--default-ext EXT] 
-                ((-o|--orphans) | (-u|--unreachable) | (-s|--subgraph NODE) | 
-                  (-b|--backlinks NODE)) [--inc-static True|False] 
-                [--inc-nonex True|False] [--tag-direction In|Out|Both]
+md-graph - A utility for graph operations on a collection of markdown files
 
-  A utility for graph operations on a collection of markdown files
+Usage: md-graph [(-l|--library FILE|DIR) [-l|--library FILE|DIR]] 
+                [-d|--default-ext EXT] COMMAND
+
+Available options:
+  -h,--help                Show this help text
+  -l,--library FILE|DIR    Files or directories to parse
+  -l,--library FILE|DIR    Files or directories to parse
+  -d,--default-ext EXT     Default extension to use for files linked without
+                           extension (default: "md")
+
+Available commands:
+  subgraph                 The subgraph of a node
+  backlinks                The backlinks (reverse subgraph) of a node
+  unreachable              Files that are not linked to
+  orphans                  Files without any links
+  nonexistant              Links that cannot be resolved
+  static                   Links that can be resolved but are not notes
+```
+- `-l, --library` Optional, defaults to the current working directory. The 
+    folders or files to include in the graph. Folders will be recursively 
+    searched.
+- `-d, --default-extension` Default `md`. Extension to use for 
+    links that do not specify an extension (like WikiLinks and VimWiki markdown 
+    links)
+
+### Subgraph
+```
+Usage: md-graph subgraph NODES [--inc-nonex True|False] [--inc-static 
+True|False] [--tag-direction In|Out|Both]
+                         [--depth ARG]
+  The subgraph of a node
+
+Available options:
+  NODES                    Nodes (files or #tags) to process
+  --inc-nonex True|False   Include non-existent files in output (default: False)
+  --inc-static True|False  Include static files in output (default: True)
+  --tag-direction In|Out|Both
+                           Change the direction of tags (default: In)
+  --depth ARG              How deep traversal should go (default: -1)
+  -h,--help                Show this help text
+```
+- `--inc-static=True|False` Default `True`. Includes static files in 
+    the output (files that were linked to and can be resolved)
+- `--inc-nonex=True|False` Default `False`. Includes non-existent files in 
+    the output (files that were linked to but can not be resolved - includes 
+    HTTP links)
+- `--tag-direction=In|Out|Both` Default `In`. Controls how tags are added to 
+    the graph from the perspective of the tag.
+    - `In`: The link is coming **in** to the tag from the file
+    - `Out`: The link is from the tag **out** to the file
+    - `Both`: The tag and the file **both** have links to each other.
+
+### Backlinks
+```
+Usage: md-graph backlinks NODES [--depth ARG]
+  The backlinks (reverse subgraph) of a node
+
+Available options:
+  NODES                    Nodes (files or #tags) to process
+  --depth ARG              How deep traversal should go (default: 1)
+  -h,--help                Show this help text
 ```
 
-- `-l, --library` Required. The folders or files to include in the graph. 
-    Folders will be recursively searched.
-- Required, one of:
-    - `-o, --orphans` Find files that are not linked to or from
-    - `-u, --unreachable` Find files that are not linked to
-    - `-s, --subgraph NODE` Given a [node](#nodes-files--tags), find its 
-        subgraph: its forward links, its forward links's forward links, etc
-    - `-b, --backlink NODE` Given a [node](#nodes-files--tags), find its 
-        backlinks
 - Optional:
-    - `-d, --default-extension` Default `md`. Extension to use for 
-        links that do not specify an extension (like WikiLinks and VimWiki markdown 
-        links)
-    - `--inc-static=True|False` Default `True`. Includes static files in 
-        the output (files that were linked to and can be resolved)
-    - `--inc-nonex=True|False` Default `False`. Includes non-existent files in 
-        the output (files that were linked to but can not be resolved - includes 
-        HTTP links)
-    - `--tag-direction=In|Out|Both` Default `In`. Controls how tags are added to 
-        the graph from the perspective of the tag.
-        - `In`: The link is coming **in** to the tag from the file
-        - `Out`: The link is from the tag **out** to the file
-        - `Both`: The tag and the file **both** have links to each other.
 
 
 ### Nodes: Files & Tags
-Arguments that take a "`NODE`" (such as `--subgraph` and `--backlink`) can be 
-given either a file or a tag. Tags are given by including the hash just like 
-their [file-parsed counterparts](#tag-format). The following will attempt to 
-find the backlinks of the tag "my-special-tag":
-`md-graph -l "my-files" --backlink #my-special-tag`.
+Arguments that take a "`NODE`" (such as `subgraph` and `backlinks`) can be given 
+either a file or a tag. Tags are given by including the hash just like their 
+[file-parsed counterparts](#tag-format). The following will attempt to find the 
+backlinks of the tag "my-special-tag":
+`md-graph backlinks #my-special-tag`.
 
 With option `--tag-direction=Out`, you can find the subgraph of a tag.
 

--- a/README.md
+++ b/README.md
@@ -36,9 +36,8 @@ Available commands:
 
 ### Subgraph
 ```
-Usage: md-graph subgraph NODES [--inc-nonex True|False] [--inc-static 
-True|False] [--tag-direction In|Out|Both]
-                         [--depth ARG]
+Usage: md-graph subgraph NODES [--inc-nonex True|False] [--inc-static True|False]
+                               [--tag-direction In|Out|Both] [--depth ARG]
   The subgraph of a node
 
 Available options:

--- a/app/Arguments.hs
+++ b/app/Arguments.hs
@@ -23,14 +23,12 @@ import           System.FilePath               as F
 
 
 data Arguments = Arguments
-    { argLibrary :: NonEmpty FilePath
+    { argLibrary :: [FilePath]
     , argDefExt  :: FilePath
     , argCommand :: Command
     }
     deriving Show
 
--- rename to "Command"?
--- The other options (Nonex, Static, TagDir) could probably be part of this type, too
 parseCommand :: Parser Command
 parseCommand = hsubparser
     (  command
@@ -70,10 +68,10 @@ parseArguments :: Parser Arguments
 parseArguments =
     Arguments <$> parseLibrary <*> parseDefaultExt <*> parseCommand
 
-parseLibrary :: Parser (NonEmpty FilePath)
+parseLibrary :: Parser [FilePath]
 parseLibrary =
-    fromMaybe ("./" :| [])
-        <$> (optional $ some1
+    fromMaybe (["./"])
+        <$> (optional $ some
                 (strOption
                     (  long "library"
                     <> short 'l'

--- a/app/Arguments.hs
+++ b/app/Arguments.hs
@@ -58,9 +58,10 @@ parseCommand = hsubparser
            )
     )
 
-opts :: ParserInfo Arguments
+opts :: IO Arguments
 opts =
-    info (helper <*> parseArguments)
+    customExecParser (prefs disambiguate)
+        $  info (helper <*> parseArguments)
         $  fullDesc
         <> header
                "md-graph - A utility for graph operations on a collection of markdown files"

--- a/app/Command.hs
+++ b/app/Command.hs
@@ -1,0 +1,24 @@
+module Command where
+
+import           Data.List.NonEmpty
+import           Node
+import           TagDirection
+
+data Command =
+    Orphans
+      | Unreachable
+      | Nonexes
+      | Statics
+      | Subgraph SubgraphOptions
+      | Backlinks SubgraphOptions
+      deriving Show
+
+data SubgraphOptions = SubgraphOptions
+  { sgTargets    :: NonEmpty Node
+  , sgInclNonex  :: Bool
+  , sgInclStatic :: Bool
+  , sgTagDir     :: TagDirection
+  , sgDepth      :: Integer
+  }
+  deriving Show
+

--- a/app/Command.hs
+++ b/app/Command.hs
@@ -10,15 +10,21 @@ data Command =
       | Nonexes
       | Statics
       | Subgraph SubgraphOptions
-      | Backlinks SubgraphOptions
+      | Backlinks BacklinkOptions
       deriving Show
 
 data SubgraphOptions = SubgraphOptions
-  { sgTargets    :: NonEmpty Node
-  , sgInclNonex  :: Bool
-  , sgInclStatic :: Bool
-  , sgTagDir     :: TagDirection
-  , sgDepth      :: Integer
-  }
-  deriving Show
+    { sgTargets    :: [Node]
+    , sgInclNonex  :: Bool
+    , sgInclStatic :: Bool
+    , sgTagDir     :: TagDirection
+    , sgDepth      :: Integer
+    }
+    deriving Show
 
+
+data BacklinkOptions = BacklinkOptions
+    { blTargets :: [Node]
+    , blDepth   :: Integer
+    }
+    deriving Show

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,11 +1,13 @@
 module Main where
 
 import           Arguments
+import           Command
 import           Graph
 import           HashSet
 import           Lib
 import           Node
 
+import           Control.Monad
 import           Data.Foldable                 as F
 import           Data.HashMap.Lazy             as M
 import           Data.HashSet                  as S
@@ -19,22 +21,33 @@ import           System.Environment
 main :: IO ()
 main = do
     args    <- execParser opts
-    corpus' <- corpus (argDefExt args) (argTagDir args) (argLibrary args)
-    let runResult =
-            catMaybesS . S.map nodePath $ doRun corpus' (argRunType args)
-    w@Weirdos { statix, nonex } <- weirdos corpus'
-    let modStatic = if argIncStatic args
-            then runResult
-            else runResult `S.difference` statix
-        modNonex = if argIncNonex args
-            then modStatic
-            else modStatic `S.difference` nonex
-    F.mapM_ P.putStrLn modNonex
+    files   <- retrieveFiles (argDefExt args) (argLibrary args)
+    links   <- parseNodes (argDefExt args) files
+    results <- doRun' (argCommand args) links $ S.fromList files
+    F.mapM_ P.putStrLn . P.map show . S.toList $ results
 
-doRun :: Corpus -> RunType -> HashSet Node
-doRun (Corpus fwdMap bwdMap allFiles) Orphans = orphans fwdMap bwdMap allFiles
-doRun (Corpus fwdMap bwdMap allFiles) Unreachable = stranded fwdMap bwdMap
-doRun (Corpus fwdMap _ _) (Subgraph node) = subgraph fwdMap node
-doRun (Corpus _ bwdMap _) (Backlinks node) =
-    fromMaybe S.empty $ bwdMap M.!? node
+doRun' :: Command -> [(Node, Node)] -> HashSet FilePath -> IO (HashSet Node)
 
+doRun' Orphans nodes allFiles = return $ orphans fwdMap bwdMap allFiles
+    where (fwdMap, bwdMap) = buildMaps nodes
+
+doRun' Unreachable nodes allFiles = return $ stranded fwdMap bwdMap
+    where (fwdMap, bwdMap) = buildMaps nodes
+
+doRun' Nonexes nodes allFiles = do
+    let (fwdMap, bwdMap) = buildMaps nodes
+    results <- weirdos $ Corpus fwdMap bwdMap allFiles
+    return . S.map Link $ nonex results
+
+doRun' Statics nodes allFiles = do
+    let (fwdMap, bwdMap) = buildMaps nodes
+    results <- weirdos $ Corpus fwdMap bwdMap allFiles
+    return . S.map Link $ statix results
+
+doRun' (Subgraph (SubgraphOptions targets incNonex incStatic tagDir depth)) nodes allFiles
+    = return $ subgraph depth fwdGraph targets
+    where (fwdGraph, bwdGraph) = buildMaps $ adjustLinks tagDir nodes
+
+doRun' (Backlinks (SubgraphOptions targets incNonex incStatic tagDir depth)) nodes allFiles
+    = return $ subgraph depth bwdGraph targets
+    where (fwdGraph, bwdGraph) = buildMaps $ adjustLinks tagDir nodes

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -20,7 +20,7 @@ import           System.Environment
 
 main :: IO ()
 main = do
-    args    <- execParser opts
+    args    <- opts
     files   <- retrieveFiles (argDefExt args) (argLibrary args)
     links   <- parseNodes (argDefExt args) files
     results <- doRun' (argCommand args) links $ S.fromList files

--- a/md-graph.cabal
+++ b/md-graph.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: e1357a1fa4eacbff1b1f0049bf3089b9b70f3f402266a6e94c8c625ad8443409
+-- hash: c097a45e62cc38fa27da024753698a7de6e5891ced1964af12dc781a4481fe48
 
 name:           md-graph
 version:        0.1.0.0
@@ -59,6 +59,7 @@ executable md-graph
   main-is: Main.hs
   other-modules:
       Arguments
+      Command
       Environment
       Paths_md_graph
   hs-source-dirs:

--- a/md-graph.cabal
+++ b/md-graph.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: c097a45e62cc38fa27da024753698a7de6e5891ced1964af12dc781a4481fe48
+-- hash: eeeb7a3808af5e740b36a19913f2fc240cb901ba78bf7ed7eefc0a0e979f5d7f
 
 name:           md-graph
 version:        0.1.0.0
@@ -27,7 +27,6 @@ source-repository head
 
 library
   exposed-modules:
-      App
       File
       Graph
       GraphZipper
@@ -60,7 +59,6 @@ executable md-graph
   other-modules:
       Arguments
       Command
-      Environment
       Paths_md_graph
   hs-source-dirs:
       app

--- a/src/File.hs
+++ b/src/File.hs
@@ -9,14 +9,12 @@ module File
 import           Control.Applicative
 import           Control.Monad                  ( join )
 import           Control.Monad.Trans.Maybe
+import           Data.Foldable
 import           Data.Maybe
 import           Data.Traversable              as T
-import           Debug.Trace
 import           Prelude                       as P
 import           System.Directory              as D
 import           System.FilePath               as F
-
-trace' x = trace (show x) x
 
 doubleDot :: FilePath
 doubleDot = ".."
@@ -90,6 +88,6 @@ expand' p@(Dir  path) = do
     contentTypes <- catMaybes <$> T.mapM getPathType contents
     join <$> T.mapM expand' contentTypes
 
-deepFiles :: [FilePath] -> IO [FilePath]
-deepFiles files = join . catMaybes <$> T.mapM traverseDir files
+deepFiles :: (Traversable f, Foldable f) => f FilePath -> IO [FilePath]
+deepFiles files = join . catMaybes . toList <$> T.mapM traverseDir files
 

--- a/src/Graph.hs
+++ b/src/Graph.hs
@@ -8,6 +8,7 @@ import           Control.Applicative            ( (<|>) )
 import           Control.Monad                  ( foldM
                                                 , join
                                                 )
+import           Data.Foldable                 as F
 import           Data.HashMap.Lazy              ( HashMap )
 import qualified Data.HashMap.Lazy             as M
 import           Data.HashSet                   ( HashSet )
@@ -18,7 +19,6 @@ import           Data.Maybe
 import           Data.Text                     as T
 import           Data.Text.IO                  as T
 import           Data.Tuple
-import           Debug.Trace
 import           Prelude                       as P
 import           System.Directory              as D
 import           System.FilePath               as F
@@ -38,16 +38,22 @@ tags (Corpus fwd bwd _) =
   where
     flattenMap m = P.foldr S.union S.empty $ uncurry S.insert <$> M.toList m
 
-subgraph :: Graph -> Node -> HashSet Node
-subgraph graph = dfs graph S.empty
+subgraph :: Foldable f => Integer -> Graph -> f Node -> HashSet Node
+subgraph maxDepth graph targets =
+    S.fromList $ (F.toList . dfs maxDepth graph) =<< F.toList targets
 
-dfs :: Graph -> HashSet Node -> Node -> HashSet Node
-dfs graph visited file = P.foldr fold (file `S.insert` visited) children
+dfs :: Integer -> Graph -> Node -> HashSet Node
+dfs maxDepth graph file = go (0, maxDepth) graph S.empty file
   where
-    children = fromMaybe S.empty $ graph M.!? file
-    fold cur visited = if cur `S.member` visited
+    go :: (Integer, Integer) -> Graph -> HashSet Node -> Node -> HashSet Node
+    go (current, maxDepth) graph visited file = if current == maxDepth
         then visited
-        else visited `S.union` dfs graph visited cur
+        else P.foldr fold (file `S.insert` visited) children
+      where
+        children = fromMaybe S.empty $ graph M.!? file
+        fold cur visited = if cur `S.member` visited
+            then visited
+            else visited `S.union` go (current + 1, maxDepth) graph visited cur
 
 orphans :: Graph -> Graph -> HashSet FilePath -> HashSet Node
 orphans fwdGraph bwdGraph allFiles = fileNodes `S.difference` nonOrphans
@@ -59,15 +65,13 @@ stranded :: Graph -> Graph -> HashSet Node
 stranded fwdGraph bwdGraph =
     M.keysSet fwdGraph `S.difference` M.keysSet bwdGraph
 
-buildMaps :: TagDirection -> [(Node, Node)] -> (Graph, Graph)
-buildMaps tagDir fwdEdges = (fwdGraph, bwdGraph)
+buildMaps :: [(Node, Node)] -> (Graph, Graph)
+buildMaps edges = (fwdGraph, bwdGraph)
   where
-    bwdGraph          = mapFromPairs $ fmap swap fwdLinks
-    fwdGraph          = mapFromPairs $ links ++ tagsWithDirection
-    fwdLinks          = links ++ tagsWithDirection
-    tagsWithDirection = tags >>= tagSwap tagDir
-    (tags, links)     = L.partition (isTag . snd) fwdEdges
-    mapFromPairs      = M.fromListWith S.union . fmap (toSnd S.singleton)
+    bwdGraph      = mapFromPairs $ fmap swap links
+    fwdGraph      = mapFromPairs links
+    (tags, links) = L.partition (isTag . snd) edges
+    mapFromPairs  = M.fromListWith S.union . fmap (toSnd S.singleton)
 
 toSnd :: (b -> c) -> (a, b) -> (a, c)
 toSnd fn (a, b) = (a, fn b)

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -4,6 +4,9 @@ module Lib
     ( corpus
     , Weirdos(..)
     , weirdos
+    , retrieveFiles
+    , parseNodes
+    , adjustLinks
     ) where
 
 import           File
@@ -23,36 +26,36 @@ import           Data.HashSet                   ( HashSet )
 import qualified Data.HashSet                  as S
 import           Data.Hashable
 import           Data.List                     as L
+import           Data.List.NonEmpty            as NE
 import           Data.Maybe
 import           Data.Text                     as T
 import           Data.Text.IO                  as T
 import           Data.Traversable              as T
 import           Data.Tuple
-import           Debug.Trace
 import           Prelude                       as P
 import           System.Directory              as D
 import           System.FilePath               as F
 
-trace' x = trace (show x) x
-
-corpus :: FilePath -> TagDirection -> [FilePath] -> IO Corpus
+corpus :: FilePath -> TagDirection -> NonEmpty FilePath -> IO Corpus
 corpus validExt tagDir paths = do
+    files     <- retrieveFiles validExt paths
+    nodePairs <- parseNodes validExt files
+    let tagDirectionAdjustedNodePairs = nodePairs >>= tagSwap tagDir
+        (fwdMap, bwdMap)              = buildMaps tagDirectionAdjustedNodePairs
+    return $ Corpus fwdMap bwdMap (S.fromList files)
+
+adjustLinks :: TagDirection -> [(Node, Node)] -> [(Node, Node)]
+adjustLinks tagDir links = links >>= tagSwap tagDir
+
+retrieveFiles :: FilePath -> NonEmpty FilePath -> IO [FilePath]
+retrieveFiles defaultExt paths = do
     files <- fmap normalise <$> deepFiles paths
-    let applicableFiles = P.filter (F.isExtensionOf validExt) files
-    (fwdMap, bwdMap) <- buildGraphs validExt tagDir applicableFiles
-    return $ Corpus fwdMap bwdMap (S.fromList applicableFiles)
+    return $ P.filter (F.isExtensionOf defaultExt) files
 
 parseFile :: FilePath -> IO [Node]
 parseFile file = do
     content <- sieveLinks <$> T.readFile file
     return $ fromMaybe [] content
-
--- should probably flatten this so that it Just returns [(FilePath, Node)]
--- and then build the graphs later
-buildGraphs :: FilePath -> TagDirection -> [FilePath] -> IO (Graph, Graph)
-buildGraphs defaultExtension tagDir files = do
-    nodePairs <- parseNodes defaultExtension files
-    return $ buildMaps tagDir nodePairs
 
 parseNodes :: FilePath -> [FilePath] -> IO [(Node, Node)]
 parseNodes defExt files = parseToTuples files >>= T.mapM fixNodes

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -72,8 +72,8 @@ parseToTuples f = P.concat <$> T.mapM parseToTuple f
         return $ fmap (f, ) parsedNodes
 
 data Weirdos = Weirdos
-    { statix :: HashSet FilePath
-    , nonex  :: HashSet FilePath
+    { statix :: HashSet Node
+    , nonex  :: HashSet Node
     }
     deriving Show
 
@@ -87,8 +87,8 @@ weirdos (Corpus _ backward allFiles) = foldM fold
     fold w@Weirdos { statix, nonex } file = do
         xists <- D.doesPathExist file
         return $ if xists
-            then w { statix = file `S.insert` statix }
-            else w { nonex = file `S.insert` nonex }
+            then w { statix = Link file `S.insert` statix }
+            else w { nonex = Link file `S.insert` nonex }
 
 fixNode :: FilePath -> FilePath -> Node -> IO Node
 fixNode defExt source (  Link path) = Link <$> fixLink defExt source path

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -47,7 +47,8 @@ corpus validExt tagDir paths = do
 adjustLinks :: TagDirection -> [(Node, Node)] -> [(Node, Node)]
 adjustLinks tagDir links = links >>= tagSwap tagDir
 
-retrieveFiles :: FilePath -> NonEmpty FilePath -> IO [FilePath]
+retrieveFiles
+    :: (Traversable f, Foldable f) => FilePath -> f FilePath -> IO [FilePath]
 retrieveFiles defaultExt paths = do
     files <- fmap normalise <$> deepFiles paths
     return $ P.filter (F.isExtensionOf defaultExt) files

--- a/src/Node.hs
+++ b/src/Node.hs
@@ -6,7 +6,11 @@ import           Data.Text                     as T
 import           GHC.Generics                   ( Generic )
 
 data Node = Link { linkPath :: FilePath } | Tag { tagLabel :: Text }
-    deriving (Show, Eq, Generic)
+    deriving (Eq, Generic)
+
+instance Show Node where
+    show (Link l) = l
+    show (Tag  t) = T.unpack t
 
 instance Hashable Node where
 

--- a/src/PParser.hs
+++ b/src/PParser.hs
@@ -1,6 +1,6 @@
 module PParser
-    ( sieveLinks
-    ) where
+  ( sieveLinks
+  ) where
 
 import           Control.Applicative
 import           Data.HashSet                  as S
@@ -20,45 +20,42 @@ import           Text.Pandoc.Readers            ( readMarkdown
                                                 )
 import           Text.Pandoc.Walk               ( query )
 
-import           Debug.Trace
 
 import           Node
 
-trace' x = trace (show x) x
 
 sieveLinks :: Text -> Maybe [Node]
 sieveLinks content = either (const Nothing) (Just . S.toList) allLinks
-  where
-    mdLinks  = extractMarkdownLinks content
-    vwLinks  = extractVimWikiLinks content
-    tags     = query extractTag <$> (runPure . readVimwiki def $ content)
-    fUnion   = liftA2 S.union
-    allLinks = mdLinks `fUnion` vwLinks `fUnion` tags
+ where
+  mdLinks  = extractMarkdownLinks content
+  vwLinks  = extractVimWikiLinks content
+  tags     = query extractHashTag <$> (runPure . readVimwiki def $ content)
+  fUnion   = liftA2 S.union
+  allLinks = mdLinks `fUnion` vwLinks `fUnion` tags
 
 extractUrl :: Inline -> HashSet Node
 extractUrl (Pandoc.Link _ _ (path, title)) =
-    S.singleton . Link . T.unpack $ ignoreAnchors path
+  S.singleton . Link . T.unpack $ ignoreAnchors path
 -- if you've got anchors in your image URLs what are you doing
 extractUrl (Image _ _ (path, title)) =
-    S.singleton . Link . T.unpack $ ignoreAnchors path
+  S.singleton . Link . T.unpack $ ignoreAnchors path
 extractUrl _ = S.empty
 
 ignoreAnchors :: Text -> Text
 ignoreAnchors = T.takeWhile (/= '#')
 
 -- Pandoc splits Str on whitespace; they are whitespace-less
-extractTag :: Inline -> HashSet Node
-extractTag (Str tag) = case T.uncons tag of
-    Just ('#', tagText) -> if T.all isValidTagChar tagText
-        then S.singleton $ Tag tagText
-        else S.empty
-    Just _  -> S.empty
-    Nothing -> S.empty
-  where
-    validTagChars = S.fromList
-        $ P.concat [['a' .. 'z'], ['A' .. 'Z'], ['0' .. '9'], ['-', '_']]
-    isValidTagChar = flip S.member validTagChars
-extractTag _ = S.empty
+extractHashTag :: Inline -> HashSet Node
+extractHashTag (Str tag) = case T.uncons tag of
+  Just ('#', tagText) ->
+    if T.all isValidTagChar tagText then S.singleton $ Tag tagText else S.empty
+  Just _  -> S.empty
+  Nothing -> S.empty
+ where
+  validTagChars =
+    S.fromList $ P.concat [['a' .. 'z'], ['A' .. 'Z'], ['0' .. '9'], ['-', '_']]
+  isValidTagChar = flip S.member validTagChars
+extractHashTag _ = S.empty
 
 extractMarkdownLinks :: Text -> Either PandocError (HashSet Node)
 extractMarkdownLinks t = query extractUrl <$> (runPure . readMarkdown def $ t)

--- a/src/TagDirection.hs
+++ b/src/TagDirection.hs
@@ -6,7 +6,6 @@ data TagDirection = In | Out | Both
     deriving Show
 
 tagSwap :: TagDirection -> (Node, Node) -> [(Node, Node)]
-tagSwap In   tup           = [tup]
-tagSwap Out  (source, tag) = [(tag, source)]
-tagSwap Both tup           = tup : tagSwap Out tup
-
+tagSwap Out  (    source, t@(Tag _)) = [(t, source)]
+tagSwap Both tup@(source, t@(Tag _)) = tup : tagSwap Out tup
+tagSwap _    tup                     = [tup]


### PR DESCRIPTION
Switching to a subcommand CLI style is much more intuitive than exclusive flags. It also made it easier to switch to a shallow embedded DSL type of code structure.