### PR TITLE
Fix: Unescape Markdown Links (%20 issue)

### DIFF
--- a/md-graph.cabal
+++ b/md-graph.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: eeeb7a3808af5e740b36a19913f2fc240cb901ba78bf7ed7eefc0a0e979f5d7f
+-- hash: 5bf59bce2d2d809d2cd58b43f1dbcee5c1860778428154ef93a1119fe5f52b2a
 
 name:           md-graph
 version:        0.1.0.0
@@ -29,7 +29,6 @@ library
   exposed-modules:
       File
       Graph
-      GraphZipper
       HashSet
       Lib
       Node
@@ -45,7 +44,7 @@ library
     , directory
     , filepath
     , hashable
-    , mtl
+    , network-uri
     , optparse-applicative
     , pandoc
     , pandoc-types
@@ -70,7 +69,7 @@ executable md-graph
     , filepath
     , hashable
     , md-graph
-    , mtl
+    , network-uri
     , optparse-applicative
     , pandoc
     , pandoc-types
@@ -94,7 +93,7 @@ test-suite md-graph-test
     , filepath
     , hashable
     , md-graph
-    , mtl
+    , network-uri
     , optparse-applicative
     , pandoc
     , pandoc-types

--- a/package.yaml
+++ b/package.yaml
@@ -26,10 +26,10 @@ dependencies:
 - directory
 - filepath
 - hashable
+- network-uri
 - optparse-applicative
 - pandoc
 - pandoc-types
-- mtl
 - text
 - transformers
 - unordered-containers

--- a/src/PParser.hs
+++ b/src/PParser.hs
@@ -1,10 +1,14 @@
 module PParser
-  ( sieveLinks
-  ) where
+    ( sieveLinks
+    ) where
+
+import           Node
 
 import           Control.Applicative
 import           Data.HashSet                  as S
 import           Data.Text                     as T
+import qualified Network.URI                   as URI
+                                                ( unEscapeString )
 import           Prelude                       as P
 import           Text.Pandoc.Class              ( runPure )
 import           Text.Pandoc.Definition        as Pandoc
@@ -20,25 +24,22 @@ import           Text.Pandoc.Readers            ( readMarkdown
                                                 )
 import           Text.Pandoc.Walk               ( query )
 
-
-import           Node
-
-
 sieveLinks :: Text -> Maybe [Node]
 sieveLinks content = either (const Nothing) (Just . S.toList) allLinks
- where
-  mdLinks  = extractMarkdownLinks content
-  vwLinks  = extractVimWikiLinks content
-  tags     = query extractHashTag <$> (runPure . readVimwiki def $ content)
-  fUnion   = liftA2 S.union
-  allLinks = mdLinks `fUnion` vwLinks `fUnion` tags
+  where
+    mdLinks  = extractMarkdownLinks content
+    vwLinks  = extractVimWikiLinks content
+    tags     = query extractHashTag <$> (runPure . readVimwiki def $ content)
+    fUnion   = liftA2 S.union
+    allLinks = mdLinks `fUnion` vwLinks `fUnion` tags
 
 extractUrl :: Inline -> HashSet Node
 extractUrl (Pandoc.Link _ _ (path, title)) =
-  S.singleton . Link . T.unpack $ ignoreAnchors path
+    -- pandoc URI escapes (%20) markdown links
+    S.singleton . Link . URI.unEscapeString . T.unpack $ ignoreAnchors path
 -- if you've got anchors in your image URLs what are you doing
 extractUrl (Image _ _ (path, title)) =
-  S.singleton . Link . T.unpack $ ignoreAnchors path
+    S.singleton . Link . T.unpack $ ignoreAnchors path
 extractUrl _ = S.empty
 
 ignoreAnchors :: Text -> Text
@@ -47,14 +48,15 @@ ignoreAnchors = T.takeWhile (/= '#')
 -- Pandoc splits Str on whitespace; they are whitespace-less
 extractHashTag :: Inline -> HashSet Node
 extractHashTag (Str tag) = case T.uncons tag of
-  Just ('#', tagText) ->
-    if T.all isValidTagChar tagText then S.singleton $ Tag tagText else S.empty
-  Just _  -> S.empty
-  Nothing -> S.empty
- where
-  validTagChars =
-    S.fromList $ P.concat [['a' .. 'z'], ['A' .. 'Z'], ['0' .. '9'], ['-', '_']]
-  isValidTagChar = flip S.member validTagChars
+    Just ('#', tagText) -> if T.all isValidTagChar tagText
+        then S.singleton $ Tag tagText
+        else S.empty
+    Just _  -> S.empty
+    Nothing -> S.empty
+  where
+    validTagChars = S.fromList
+        $ P.concat [['a' .. 'z'], ['A' .. 'Z'], ['0' .. '9'], ['-', '_']]
+    isValidTagChar = flip S.member validTagChars
 extractHashTag _ = S.empty
 
 extractMarkdownLinks :: Text -> Either PandocError (HashSet Node)


### PR DESCRIPTION
By default, when pandoc parses a markdown link it also escapes the link as a uri. So `[link](foo bar baz)` gets parsed as `foo%20bar%baz`. This is quite good for browser-destined markdown but when we try to resolve it in the filesystem it will be taken literally and fail.