### PR TITLE
[Fix][Tiny] Update link to Neuron notes system in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Graph operations on a collection of interlinked Markdown (or 
 [VimWiki](https://github.com/vimwiki/vimwiki), [ZimWiki](https://zim-wiki.org/), 
 [Zettlr](https://www.zettlr.com/), [Obsidian](https://obsidian.md/), or 
-[Neuron](https://obsidian.md/)) notes.
+[Neuron](https://neuron.zettel.page/)) notes.
 
 md-graph seeks to enrich an existing library of interlinked notes but not change 
 how notes are written for the sake of its use. This enables interoperation with 


### PR DESCRIPTION
Update readme to provide correct link to to the referenced Neuron notes system.

Resolves #14 